### PR TITLE
Set up dev environment (AGENTS.md + startup update script)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,41 @@
+# AGENTS.md
+
+## Cursor Cloud specific instructions
+
+This is a single **Django 4.2** project (`mysite`) that serves three apps under one dev server:
+`blog` (`/blog/`), `polls` (`/polls/`), and `user_manager` (`/user/`, `/contact/`), plus Django
+admin (`/admin/`) and allauth social login (`/accounts/`). There is no separate frontend build
+and no external services are required — the default database is SQLite and static files are served
+in-process by WhiteNoise.
+
+### Environment
+
+- Python dependencies live in a virtualenv at `.venv/` (gitignored). Activate with
+  `source .venv/bin/activate`, or call binaries directly via `.venv/bin/python`.
+- The startup update script keeps `.venv` in sync with `requirements.txt`. It does NOT run
+  database migrations (see below).
+
+### Running the app (dev)
+
+- Standard commands are documented in `README.md`. In short, after activating the venv:
+  - `python manage.py migrate` — required on a fresh VM because `db.sqlite3` is gitignored and
+    NOT part of the repo/snapshot, so the database must be (re)created before the server will work.
+  - `python manage.py runserver 0.0.0.0:8000` — dev server.
+- There is no admin user by default. Create one for testing the admin / login-gated flows, e.g.
+  `DJANGO_SUPERUSER_PASSWORD=admin12345 python manage.py createsuperuser --username admin --email admin@example.com --noinput`.
+
+### Lint / test / build
+
+- Lint / system check: `python manage.py check`
+- Tests: `python manage.py test polls mysite blog user_manager` (README lists `polls mysite`;
+  `blog` and `user_manager` also have tests).
+- No build step is required (WhiteNoise serves static files; `collectstatic` is only needed for
+  prod-style serving).
+
+### Gotchas
+
+- `python` may not be on PATH outside the venv; use `python3` or the activated venv's `python`.
+- Optional integrations are off by default and need no setup for core flows: PostgreSQL
+  (`USE_POSTGRES=1` / `DATABASE_URL`), SMTP email (password reset), and OAuth providers
+  (Google/Facebook/Instagram via allauth).
+- `django-debug-toolbar` only loads when `DEBUG=True` and not running tests.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Sets up the development environment for this Django 4.2 project and documents it for future Cursor Cloud agents.

- Adds `AGENTS.md` with a `## Cursor Cloud specific instructions` section covering how to run/lint/test the app, plus non-obvious gotchas (e.g. `db.sqlite3` is gitignored so `migrate` is required on a fresh VM; `python` may not be on PATH outside the venv).
- Configures a minimal, idempotent startup update script that refreshes the `.venv` from `requirements.txt`.

## Environment details

- **Stack:** Python 3.12 + Django 4.2 (SQLite default, WhiteNoise static, django-allauth). No external services required for core flows.
- **Install:** virtualenv at `.venv/`, `pip install -r requirements.txt`.
- **Run (dev):** `python manage.py migrate` then `python manage.py runserver`.

## Verification

- `python manage.py check` → no issues.
- `python manage.py test polls mysite blog user_manager` → 11 tests, all pass.
- Dev server serves `/blog/` (200), `/polls/` (200), `/user/login/` (200), `/admin/` (302).
- End-to-end "hello world": logged in and created a blog post via the UI, which then appears in the blog list and detail page.

[django_blog_create_post_demo.mp4](https://cursor.com/agents/bc-a82a9535-14c4-4a16-9c80-44dbc99ba761/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fdjango_blog_create_post_demo.mp4)

[Blog list showing created post](https://cursor.com/agents/bc-a82a9535-14c4-4a16-9c80-44dbc99ba761/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fblog_list.webp)

Note: only `AGENTS.md` is added; no application code was modified.

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a82a9535-14c4-4a16-9c80-44dbc99ba761?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a82a9535-14c4-4a16-9c80-44dbc99ba761&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

